### PR TITLE
Fix ambiguous SQL when using UserId.

### DIFF
--- a/lib/private/api_statistic.php
+++ b/lib/private/api_statistic.php
@@ -69,12 +69,12 @@
                 
             if (count($Users) == 1)
             {         
-                array_push($Conditions, 'UserId=?');
+                array_push($Conditions, '`'.RP_TABLE_PREFIX.'User`.UserId=?');
                 array_push($Parameters, $Users[0]);
             }
             else
             {
-                array_push($Conditions, 'UserId IN ('.implode(',',$Users).')');
+                array_push($Conditions, '`'.RP_TABLE_PREFIX.'User`.UserId IN ('.implode(',',$Users).')');
             }
         }
         


### PR DESCRIPTION
When using the "users=id" or "users=id,id,id" I was getting a SQL ambiguous error.

Note this will still return an empty result as issue #107 is still not fixed.
